### PR TITLE
Add support for new Microsoft Teams (work or school)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 RobertD502
+Copyright (c) 2024 RobertD502
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -2,13 +2,11 @@
 <a href="https://www.buymeacoffee.com/RobertD502" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/default-orange.png" alt="Buy Me A Coffee" height="50" width="212"></a>
 <a href="https://liberapay.com/RobertD502/donate"><img alt="Donate using Liberapay" src="https://liberapay.com/assets/widgets/donate.svg" height="50" width="150"></a>
 
-> [!Caution]
->
-> At the moment, this does not work with the new Microsoft Teams app (titled "Microsoft Teams (work and school)"). The new app is not writing to the "logs.txt" file (most likely due to a bug). This message will be removed once Microsoft fixes this bug and, if the logging differs, once changes are made to the scripts to account for the new logging behavior.
+Although the Home Assistant MacOS companion app allows you to use the state of your camera and microphone to determine if you are in a Teams meeting, this method doesn't work if you are in a meeting with both off. The aim of this project is to send your meeting status (In meeting, Not in meeting) to Home Assistant without relying on the status of your camera or microphone.
+* If using the old Microsoft Teams application: This is accomplished by reading the Microsoft Teams log.
+* If you are using the new version of Microsoft Teams (titled `Microsoft Teams (work or school)`): Microsoft no longer writes the state to the log file. This script works around the limitation by looking at the `powerd` process' logs to determine if/if not in a meeting.
 
-
-Although the Home Assistant MacOS companion app allows you to use the state of your camera and microphone to determine if you are in a Teams meeting, this method doesn't work if you are in a meeting with both off. The aim of this project is to send your meeting status (In meeting, Not in meeting) to Home Assistant without relying on the status of your camera or microphone. This is accomplished by reading the Microsoft Teams log and forwarding the status to Home Assistant.
-The Microsoft Teams log is automatically checked every 2 seconds and the current state is sent to Home Assistant if it differs from the previous state.
+Regardless of which of the two methods mentioned above applies to you, the logs are automatically checked every 2 seconds and the current state is sent to Home Assistant if it differs from the previous state.
 
 ## Important Note
 There are two different methods titled `Local` and `External`.
@@ -80,9 +78,10 @@ Note: The `Library` folder is a hidden folder. In order to see it, while inside 
 
 ### Edit the script file
 1. Open the `ms-teams-status-local.sh` file (located in your Teams_Status folder) in an editor of your choosing.
-2. Place your token inside of the `token` variable
-3. Place your local Home Assistant URL inside the `local_url` variable, e.g., `"http://192.168.1.42:8123"`
-4. Save the changes.
+2. Change the `teams_version` variable to EITHER "Old" (including quotation marks) if you are using the old MS Teams or "New" (including quotation marks) if you are using the new version of MS Teams, also referred to as `Microsoft Teams (work or school)`
+3. Place your token inside of the `token` variable
+4. Place your local Home Assistant URL inside the `local_url` variable, e.g., `"http://192.168.1.42:8123"`
+5. Save the changes.
 
 ### Load the plist file
 On your Mac, open a terminal window and execute the following command:
@@ -90,7 +89,7 @@ On your Mac, open a terminal window and execute the following command:
 launchctl load -w ~/Library/LaunchAgents/com.homeassistant.MSTeamsStatusSender-Local.plist
 ```
 
-That's it! Whenever you are logged in on your Mac, the script will run every 2 seconds and update the input_text.microsoft_teams_status entity if the current meeting state from the Teams log differs from the previous state.
+That's it! Whenever you are logged in on your Mac, the script will run every 2 seconds and update the input_text.microsoft_teams_status entity if the current meeting state differs from the previous state.
 
 </details>
 
@@ -149,8 +148,9 @@ For those that prefer YAML, this is the full YAML for the automation above:
 
 ### Edit the script file
 1. Open the `ms-teams-status-external.sh` file (located in your Teams_Status folder) in an editor of your choosing.
-2. Place your webhook url inside the `webhook_url` variable
-3. Save the changes.
+2. Change the `teams_version` variable to EITHER "Old" (including quotation marks) if you are using the old MS Teams or "New" (including quotation marks) if you are using the new version of MS Teams, also referred to as `Microsoft Teams (work or school)`
+3. Place your webhook url inside the `webhook_url` variable
+4. Save the changes.
 
 ### Load the plist file
 On your Mac, open a terminal window and execute the following command:
@@ -158,7 +158,7 @@ On your Mac, open a terminal window and execute the following command:
 launchctl load -w ~/Library/LaunchAgents/com.homeassistant.MSTeamsStatusSender-External.plist
 ```
 
-That's it! Whenever you are logged in on your Mac, the script will run every 2 seconds and update the input_text.microsoft_teams_status entity if the current meeting state from the Teams log differs from the previous state.
+That's it! Whenever you are logged in on your Mac, the script will run every 2 seconds and update the input_text.microsoft_teams_status entity if the current meeting state differs from the previous state.
 
 </details>
 

--- a/ms-teams-status-external.sh
+++ b/ms-teams-status-external.sh
@@ -6,21 +6,61 @@
 #Author       :Robert Drinovac
 #GitHub       :https://www.github.com/RobertD502/TeamsStatusMacOS
 #License      :MIT
-#version      :0.1
+#version      :0.2
 #####################################################################################
 
+teams_version="Old | New" # Set this to EITHER "Old" or "New" depending on the teams version you are using (See GitHub documentation)
 webhook_url="YOUR_WEBHOOK" # Make sure your webhook url is inside quotation marks
 previous_state_file=~/Documents/Teams_Status/previous_state.txt
-fetched_log=$(grep "eventpdclevel: 2, name: desktop_call_state_change_send" ~/Library/Application\ Support/Microsoft/Teams/logs.txt | tail -1)
-if [ -n "$fetched_log" ]; then
-      in_meeting_count=$(printf %s "$fetched_log" | grep -Fo "isOngoing: true" | wc -l)
-      if [ "$in_meeting_count" -eq 1 ]; then
-            meeting_status="In meeting"
+powerd_log_file=~/Documents/Teams_Status/powerd_log.txt
+
+#For first time usage, make sure previous state file is created
+if [ ! -f "$previous_state_file" ]; then
+      echo "previous_state: Unknown" > $previous_state_file
+fi
+
+# Handle New Teams version
+if [ "$teams_version" == "New" ]; then
+      # Fetch 30 min of powerd process' logs and locate event messages
+      # related to MS Teams call.
+      log show --style syslog --last 30m --process "powerd" > $powerd_log_file
+      teams_event=$(grep "Microsoft Teams Call in progress" "$powerd_log_file" | tail -1)
+      # Determine the meeting status based on the most recent status in powerd log
+      if [ -n "$teams_event" ]; then
+            in_meeting_count=$(printf %s "$teams_event" | grep -Fo "Created" | wc -l)
+            left_meeting_count=$(printf %s "$teams_event" | grep -Fo "Released" | wc -l)
+            if [ "$in_meeting_count" -eq 1 ]; then
+                  meeting_status="In meeting"
+            elif [ "$left_meeting_count" -eq 1 ]; then
+                  meeting_status="Not in meeting"
+            # We may get an event regarding a teams call, but it isn't regarding
+            # either a call being started or ended, so, we will use the last
+            # state that was recorded.
+            else
+                  previous_state=$(grep "previous_state:" "$previous_state_file" | cut -d ' ' -f 2,3,4)
+                  meeting_status="$previous_state"
+            fi
+      # User might be in a meeting longer than 30 minutes.
+      # In that case, powerd logs may not return any related
+      # messages and we need to use the last meeting status that was
+      # recorded.
       else
-            meeting_status="Not in meeting"
+            previous_state=$(grep "previous_state:" "$previous_state_file" | cut -d ' ' -f 2,3,4)
+            meeting_status="$previous_state"
       fi
+# Handle Old MS Teams where state was written to its log file
 else
-      meeting_status="Unknown"
+      fetched_log=$(grep "eventpdclevel: 2, name: desktop_call_state_change_send" ~/Library/Application\ Support/Microsoft/Teams/logs.txt | tail -1)
+      if [ -n "$fetched_log" ]; then
+            in_meeting_count=$(printf %s "$fetched_log" | grep -Fo "isOngoing: true" | wc -l)
+            if [ "$in_meeting_count" -eq 1 ]; then
+                  meeting_status="In meeting"
+            else
+                  meeting_status="Not in meeting"
+            fi
+      else
+            meeting_status="Unknown"
+      fi
 fi
 
 sensor_state=$(cat <<EOF
@@ -30,15 +70,10 @@ sensor_state=$(cat <<EOF
 EOF
 )
 
-# Create a new previous_state.txt file if one isn't present
-if [ ! -f "$previous_state_file" ]; then
-      echo "previous_state:" >> "$previous_state_file"
-fi
-
 previous_state=$(grep "previous_state:" "$previous_state_file")
 # Only send the state if the state has changed
 if [ "$previous_state" != "previous_state: $meeting_status" ]; then
       # Replace last state with new state
-      echo "previous_state: $meeting_status" > "$previous_state_file"
+      echo "previous_state: $meeting_status" > $previous_state_file
       curl -s -X POST -H "content-type: application/json" --data-raw "$sensor_state" $webhook_url
 fi

--- a/ms-teams-status-local.sh
+++ b/ms-teams-status-local.sh
@@ -6,25 +6,64 @@
 #Author       :Robert Drinovac
 #GitHub       :https://www.github.com/RobertD502/TeamsStatusMacOS
 #License      :MIT
-#version      :0.1
+#version      :0.2
 #####################################################################################
 
+teams_version="Old | New" # Set this to EITHER "Old" or "New" depending on the teams version you are using (See GitHub documentation)
 token="YOUR_LONG_LIVED_TOKEN" # Make sure your token is inside of quotation marks
 local_url="http://HOME_ASSISTANT_IP:8123" # Make sure your url is inside of quotation marks
 full_url="$local_url/api/states/input_text.microsoft_teams_status"
 previous_state_file=~/Documents/Teams_Status/previous_state.txt
-fetched_log=$(grep "eventpdclevel: 2, name: desktop_call_state_change_send" ~/Library/Application\ Support/Microsoft/Teams/logs.txt | tail -1)
+powerd_log_file=~/Documents/Teams_Status/powerd_log.txt
 
-# Determine the meeting status based on the most recent status in MS Teams log
-if [ -n "$fetched_log" ]; then
-      in_meeting_count=$(printf %s "$fetched_log" | grep -Fo "isOngoing: true" | wc -l)
-      if [ "$in_meeting_count" -eq 1 ]; then
-            meeting_status="In meeting"
+#For first time usage, make sure previous state file is created
+if [ ! -f "$previous_state_file" ]; then
+      echo "previous_state: Unknown" > $previous_state_file
+fi
+
+# Handle New Teams version
+if [ "$teams_version" == "New" ]; then
+      # Fetch 30 min of powerd process' logs and locate event messages
+      # related to MS Teams call.
+      log show --style syslog --last 30m --process "powerd" > $powerd_log_file
+      teams_event=$(grep "Microsoft Teams Call in progress" "$powerd_log_file" | tail -1)
+
+      # Determine the meeting status based on the most recent status in powerd log
+      if [ -n "$teams_event" ]; then
+            in_meeting_count=$(printf %s "$teams_event" | grep -Fo "Created" | wc -l)
+            left_meeting_count=$(printf %s "$teams_event" | grep -Fo "Released" | wc -l)
+            if [ "$in_meeting_count" -eq 1 ]; then
+                  meeting_status="In meeting"
+            elif [ "$left_meeting_count" -eq 1 ]; then
+                  meeting_status="Not in meeting"
+            # We may get an event regarding a teams call, but it isn't regarding
+            # either a call being started or ended, so, we will use the last
+            # state that was recorded.
+            else
+                  previous_state=$(grep "previous_state:" "$previous_state_file" | cut -d ' ' -f 2,3,4)
+                  meeting_status="$previous_state"
+            fi
+      # User might be in a meeting longer than 30 minutes.
+      # In that case, powerd logs may not return any related
+      # messages and we need to use the last meeting status that was
+      # recorded.
       else
-            meeting_status="Not in meeting"
+            previous_state=$(grep "previous_state:" "$previous_state_file" | cut -d ' ' -f 2,3,4)
+            meeting_status="$previous_state"
       fi
+# Handle Old MS Teams where state was written to its log file
 else
-      meeting_status="Unknown"
+      fetched_log=$(grep "eventpdclevel: 2, name: desktop_call_state_change_send" ~/Library/Application\ Support/Microsoft/Teams/logs.txt | tail -1)
+      if [ -n "$fetched_log" ]; then
+            in_meeting_count=$(printf %s "$fetched_log" | grep -Fo "isOngoing: true" | wc -l)
+            if [ "$in_meeting_count" -eq 1 ]; then
+                  meeting_status="In meeting"
+            else
+                  meeting_status="Not in meeting"
+            fi
+      else
+            meeting_status="Unknown"
+      fi
 fi
 
 # Create the JSON that will be sent to Home Assistant
@@ -38,15 +77,10 @@ sensor_state=$(cat <<EOF
 EOF
 )
 
-# Create a new previous_state.txt file if one isn't present
-if [ ! -f "$previous_state_file" ]; then
-      echo "previous_state:" >> "$previous_state_file"
-fi
-
 previous_state=$(grep "previous_state:" "$previous_state_file")
 # Only send the state if the state has changed
 if [ "$previous_state" != "previous_state: $meeting_status" ]; then
       # Replace last state with new state
-      echo "previous_state: $meeting_status" > "$previous_state_file"
+      echo "previous_state: $meeting_status" > $previous_state_file
       curl -s -X POST -H "authorization: Bearer $token" -H "content-type: application/json" --data-raw "$sensor_state" $full_url
 fi


### PR DESCRIPTION
- use `powerd` process' logs to determine if in a meeting or not when using the new version of Microsoft Teams.